### PR TITLE
Dispose of path before creating a new one.

### DIFF
--- a/src/ImageCircle.Forms.Plugin.Android/ImageCircleRenderer.cs
+++ b/src/ImageCircle.Forms.Plugin.Android/ImageCircleRenderer.cs
@@ -105,6 +105,7 @@ namespace ImageCircle.Forms.Plugin.Droid
 
                 var result = base.DrawChild(canvas, child, drawingTime);
 
+                path.Dispose();
                 canvas.Restore();
 
                 path = new Path();


### PR DESCRIPTION
Two `Path` objects are assigned to this variable but only the second one gets disposed. It looks like this might cause a memory leak.