### PR TITLE
Fix nuspec for UWP

### DIFF
--- a/nuget/Plugin.nuspec
+++ b/nuget/Plugin.nuspec
@@ -67,7 +67,7 @@
 
      <!--UWP-->
      <file src="src\ImageCircle.Forms.Plugin.UWP\bin\Release\ImageCircle.Forms.Plugin.*" target="lib\UAP10" />
-
+     <file src="src\ImageCircle.Forms.Plugin.UWP\Properties\*.rd.xml" target="lib\UAP10\ImageCircle.Forms.Plugin.UWP\Properties" />
    
    </files>
 </package>


### PR DESCRIPTION
When building an UWP app with this package, this error occurs :

>  ImageCircle.Forms.Plugin.UWP.rd.xml doesn't exist.

The nuspec file does not contain the rule to copy this file, this PR add it.

Changes Proposed in this pull request:
- Correct nuspec for UWP platform
